### PR TITLE
Fix shjs bin path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MIT",
   "bin": {
-    "shjs": "./bin/shjs"
+    "shjs": "./bin/transpile.js"
   },
   "devDependencies": {
     "deploy-gh": "^0.1.1",


### PR DESCRIPTION
Currently install this package will throw following errors: 

```
npm ERR! Darwin 16.0.0
npm ERR! argv "/Users/Jhen/.nvm/versions/node/v6.2.2/bin/node" "/Users/Jhen/.nvm/versions/node/v6.2.2/bin/npm" "i" "shelljs-transpiler"
npm ERR! node v6.2.2
npm ERR! npm  v3.10.5
npm ERR! path /Users/Jhen/test-shjs/node_modules/shelljs-transpiler/bin/shjs
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod

npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/Jhen/test-shjs/node_modules/shelljs-transpiler/bin/shjs'
npm ERR! enoent ENOENT: no such file or directory, chmod '/Users/Jhen/test-shjs/node_modules/shelljs-transpiler/bin/shjs'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/Jhen/test-shjs/npm-debug.log
```