### PR TITLE
Adding case statement and passing context to the recursive call

### DIFF
--- a/bin/sh2js
+++ b/bin/sh2js
@@ -59,12 +59,12 @@ if (m.failed()) {
 
 var s = bash.createSemantics();
 s.addOperation(
-  'toJS(indent)',
+  'toJS(indent, ctx)',
   semantics.source2sourceSemantics);
 
 var n = s(m);
 
-var jsResult = n.toJS(0);
+var jsResult = n.toJS(0, {});
 if (argv._[1]) { // write it out to a file
   ShellString(jsResult).to(argv._[1]);
 } else { // write it to stdout

--- a/scripts/runtests.js
+++ b/scripts/runtests.js
@@ -17,7 +17,7 @@ shell.config.silent = true;
 var contents = fs.readFileSync(ohmFile);
 var bash = ohm.grammar(contents);
 var s = bash.createSemantics();
-s.addOperation('toJS(indent)', semantics.source2sourceSemantics);
+s.addOperation('toJS(indent, ctx)', semantics.source2sourceSemantics);
 
 var m;
 
@@ -41,21 +41,21 @@ assert.ok(m.failed());
 //
 
 m = bash.match('# this is a comment\necho foo\n');
-assert.equal(s(m).toJS(0), "// this is a comment\necho('foo');\n");
+assert.equal(s(m).toJS(0, {}), "// this is a comment\necho('foo');\n");
 
 m = bash.match('#this is a comment | echo foo\n');
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "//this is a comment | echo foo\n");
+assert.equal(s(m).toJS(0, {}), "//this is a comment | echo foo\n");
 
 m = bash.match('# this is a comment ; echo foo');
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "// this is a comment ; echo foo");
+assert.equal(s(m).toJS(0, {}), "// this is a comment ; echo foo");
 
 m = bash.match("if [ -f foo.txt ]; then\n" +
                "  echo hi\n" +
                "fi\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "if (test('-f', 'foo.txt')) {\n" +
+assert.equal(s(m).toJS(0, {}), "if (test('-f', 'foo.txt')) {\n" +
                            "  echo('hi');\n" +
                            "}\n");
 
@@ -63,7 +63,7 @@ m = bash.match("if test -f foo.txt; then\n" +
                "  echo hi\n" +
                "fi\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "if (test('-f', 'foo.txt')) {\n" +
+assert.equal(s(m).toJS(0, {}), "if (test('-f', 'foo.txt')) {\n" +
                            "  echo('hi');\n" +
                            "}\n");
 
@@ -71,7 +71,7 @@ m = bash.match("if test foo == foo.txt; then\n" +
                "  echo hi\n" +
                "fi\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "if ('foo' === 'foo.txt') {\n" +
+assert.equal(s(m).toJS(0, {}), "if ('foo' === 'foo.txt') {\n" +
                            "  echo('hi');\n" +
                            "}\n");
 
@@ -79,7 +79,7 @@ m = bash.match("if [ foo -ne 'foo.txt' ]; then\n" +
                "  echo hi\n" +
                "fi\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "if ('foo' !== 'foo.txt') {\n" +
+assert.equal(s(m).toJS(0, {}), "if ('foo' !== 'foo.txt') {\n" +
                            "  echo('hi');\n" +
                            "}\n");
 
@@ -87,7 +87,7 @@ m = bash.match("while true; do\n" +
                "  echo hi\n" +
                "done\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "while (exec('true').code === 0) {\n" +
+assert.equal(s(m).toJS(0, {}), "while (exec('true').code === 0) {\n" +
                            "  echo('hi');\n" +
                            "}\n");
 
@@ -95,7 +95,7 @@ m = bash.match("while test -f foo.txt; do\n" +
                "  echo hi\n" +
                "done\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "while (test('-f', 'foo.txt')) {\n" +
+assert.equal(s(m).toJS(0, {}), "while (test('-f', 'foo.txt')) {\n" +
                            "  echo('hi');\n" +
                            "}\n");
 
@@ -103,7 +103,7 @@ m = bash.match("while [ -f foo.txt ]; do\n" +
                "  echo hi\n" +
                "done\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "while (test('-f', 'foo.txt')) {\n" +
+assert.equal(s(m).toJS(0, {}), "while (test('-f', 'foo.txt')) {\n" +
                            "  echo('hi');\n" +
                            "}\n");
 
@@ -114,7 +114,7 @@ m = bash.match("while [ -f foo.txt ]; do\n" +
                "  echo $?\n" +
                "done\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "while (shell.test('-f', 'foo.txt')) {\n" +
+assert.equal(s(m).toJS(0, {}), "while (shell.test('-f', 'foo.txt')) {\n" +
                            "  shell.echo('hi');\n" +
                            "  shell.echo(shell.error());\n" +
                            "}\n");
@@ -123,7 +123,7 @@ semantics.globalInclude.value = true;
 // // Empty script
 // m = bash.match("\n");
 // assert.ok(m.succeeded());
-// assert.equal(s(m).toJS(0), "\n");
+// assert.equal(s(m).toJS(0, {}), "\n");
 
 // TODO(nate): check leading white space
 // Comments
@@ -132,105 +132,105 @@ assert.ok(m.succeeded());
 
 m = bash.match("exit\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "exit();\n");
+assert.equal(s(m).toJS(0, {}), "exit();\n");
 
 m = bash.match("exit  -43\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "exit(-43);\n");
+assert.equal(s(m).toJS(0, {}), "exit(-43);\n");
 
 m = bash.match("sed    's/foo/bar' file.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "sed(/foo/, 'bar', 'file.txt');\n");
+assert.equal(s(m).toJS(0, {}), "sed(/foo/, 'bar', 'file.txt');\n");
 
 m = bash.match("sed    's/foo/bar/' file.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "sed(/foo/, 'bar', 'file.txt');\n");
+assert.equal(s(m).toJS(0, {}), "sed(/foo/, 'bar', 'file.txt');\n");
 
 m = bash.match("sed    's/foo/bar/g' file.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "sed(/foo/g, 'bar', 'file.txt');\n");
+assert.equal(s(m).toJS(0, {}), "sed(/foo/g, 'bar', 'file.txt');\n");
 
 m = bash.match("grep    'foo' file.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "grep('foo', 'file.txt');\n");
+assert.equal(s(m).toJS(0, {}), "grep('foo', 'file.txt');\n");
 
 m = bash.match("test -d file.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "test('-d', 'file.txt');\n");
+assert.equal(s(m).toJS(0, {}), "test('-d', 'file.txt');\n");
 
 // Assignment
 m = bash.match("local foo='hi'\n" +
                "foo='bar'\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "var foo = 'hi';\n" +
+assert.equal(s(m).toJS(0, {}), "var foo = 'hi';\n" +
                            "foo = 'bar';\n");
 
 m = bash.match("readonly foo='hi'\n" +
                "foo='bar'\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "const foo = 'hi';\n" +
+assert.equal(s(m).toJS(0, {}), "const foo = 'hi';\n" +
                            "foo = 'bar';\n");
 
 // Newlines are preserved
 m = bash.match("\nreadonly foo='hi'\n\n\n" +
                "foo='bar'\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "\nconst foo = 'hi';\n\n\n" +
+assert.equal(s(m).toJS(0, {}), "\nconst foo = 'hi';\n\n\n" +
                            "foo = 'bar';\n");
 
 // Pipes and redirects
 m = bash.match("cat file.txt | grep 'foo' | sed 's/o/a/g' > out.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "cat('file.txt').grep('foo').sed(/o/g, 'a').to('out.txt');\n");
+assert.equal(s(m).toJS(0, {}), "cat('file.txt').grep('foo').sed(/o/g, 'a').to('out.txt');\n");
 
 // With goofy formatting
 m = bash.match("cat file.txt   | grep 'foo'|sed 's/o/a/g'>out.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "cat('file.txt').grep('foo').sed(/o/g, 'a').to('out.txt');\n");
+assert.equal(s(m).toJS(0, {}), "cat('file.txt').grep('foo').sed(/o/g, 'a').to('out.txt');\n");
 
 m = bash.match("sed 's/foo/bar/' foo.txt bar.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "sed(/foo/, 'bar', 'foo.txt', 'bar.txt');\n");
+assert.equal(s(m).toJS(0, {}), "sed(/foo/, 'bar', 'foo.txt', 'bar.txt');\n");
 
 // Sed supports double-quotes
 m = bash.match("sed \"s/foo/bar/\" foo.txt bar.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "sed(/foo/, 'bar', 'foo.txt', 'bar.txt');\n");
+assert.equal(s(m).toJS(0, {}), "sed(/foo/, 'bar', 'foo.txt', 'bar.txt');\n");
 
 // TestCmd tests
 m = bash.match("[ -f file.txt ]\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "test('-f', 'file.txt');\n");
+assert.equal(s(m).toJS(0, {}), "test('-f', 'file.txt');\n");
 
 m = bash.match("test -f file.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "test('-f', 'file.txt');\n");
+assert.equal(s(m).toJS(0, {}), "test('-f', 'file.txt');\n");
 
 m = bash.match("[ ! -f file.txt ]\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "!test('-f', 'file.txt');\n");
+assert.equal(s(m).toJS(0, {}), "!test('-f', 'file.txt');\n");
 
 m = bash.match("test ! -f file.txt\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "!test('-f', 'file.txt');\n");
+assert.equal(s(m).toJS(0, {}), "!test('-f', 'file.txt');\n");
 
 m = bash.match("[ ! $x = $y ]\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "!(x === y);\n");
+assert.equal(s(m).toJS(0, {}), "!(x === y);\n");
 
 m = bash.match("echo\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "echo();\n");
+assert.equal(s(m).toJS(0, {}), "echo();\n");
 
 // Variable names can have weird-ish characters
 m = bash.match("MY_var123='hi'\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "var MY_var123 = 'hi';\n");
+assert.equal(s(m).toJS(0, {}), "var MY_var123 = 'hi';\n");
 
 // Multi-line pipes
 m = bash.match("echo hi |\ncat |\ncat\n");
 assert.ok(m.succeeded());
-assert.equal(s(m).toJS(0), "echo('hi')\n  .cat()\n  .cat();\n");
+assert.equal(s(m).toJS(0, {}), "echo('hi')\n  .cat()\n  .cat();\n");
 
 shell.set('+e');
 var retStatus = 0;
@@ -259,7 +259,7 @@ shell.ls().forEach(function (test) {
       throw new Error('Unable to parse');
     } else {
       assert.ok(m.succeeded());
-      assert.equal(s(m).toJS(0), shell.cat(shell.ls('*.js')[0]));
+      assert.equal(s(m).toJS(0, {}), shell.cat(shell.ls('*.js')[0]));
     }
     console.log(greenCheckmark + ' ' + test);
   } catch (e) {

--- a/src/bash.ohm
+++ b/src/bash.ohm
@@ -15,6 +15,7 @@ Bash {
       | Export
       | Assignment
       | SimpleCmd
+      | CaseCommand
       | ("" ~keyword)
 
   IfCommand
@@ -51,6 +52,12 @@ Bash {
 
   CodeBlock
       = "{" allwhitespace* CmdSequence allwhitespace* "}"
+
+  CaseCommand
+      = "case" Bashword "in" #(allwhitespace+) NonemptyListOf<CaseCase, #(allwhitespace+)> #(allwhitespace+) "esac"
+
+  CaseCase
+      = NonemptyListOf<Bashword, "|"> ")" #(allwhitespace*) ListOf<Cmd, (~";;" semicolon)> #(allwhitespace*) (";;" | ";&") comment?
 
   BinaryOp (Binary infix operator)
       = "=="  | "=" | "-eq"
@@ -143,7 +150,7 @@ Bash {
       = keywordRoot ~alnum
 
   keywordRoot
-      = "if" | "then" | "else" | "elif" | "fi" | "for" | "done" | "do" | "function"
+      = "case" | "esac" | "if" | "then" | "else" | "elif" | "fi" | "for" | "done" | "do" | "function"
 
   stringLiteral
       = singleString

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ var s = bash.createSemantics();
 var errMessage;
 var warned = false;
 s.addOperation(
-  'toJS(indent)',
+  'toJS(indent, ctx)',
   source2sourceSemantics);
 
 function loadTranslatedText() {
@@ -46,7 +46,7 @@ function loadTranslatedText() {
   warned = false;
   if (!errMessage) {
     var n = s(m);
-    var replacementText = n.toJS(0).trimRight();
+    var replacementText = n.toJS(0, {}).trimRight();
     jscode.setValue(replacementText);
   }
 }

--- a/src/semantics.js
+++ b/src/semantics.js
@@ -20,10 +20,23 @@ function warn(message) {
   }
 }
 
+function globStringToRegex(str) {
+    function preg_quote (str, delimiter) {
+        // http://stackoverflow.com/a/13818704
+        return (str + '').replace(new RegExp('[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\' + (delimiter || '') + '-]', 'g'), '\\$&');
+    }
+
+    return new RegExp("^" + preg_quote(str).replace(/\\\*/g, '.*').replace(/\\\?/g, '.') + "$", 'g');
+}
+
+function isGlobString(str){
+  return globStringToRegex(str).toString() === "/^" + str + "$/g";
+}
+
 function testCmdHelper(negate, word1, operator, word2) {
   if (word1) {
     // binary command
-    var ret = word1.toJS(0) + ' ' + operator.toJS(0) + ' ' + word2.toJS(0);
+    var ret = word1.toJS(0, this.args.ctx) + ' ' + operator.toJS(0, this.args.ctx) + ' ' + word2.toJS(0, this.args.ctx);
     return negate.sourceString ?
         '!(' + ret + ')' :
         ret;
@@ -39,11 +52,11 @@ function testCmdHelper(negate, word1, operator, word2) {
 
     if (opString === '-z') {
       return negated ?
-        word2.toJS(0) :
-        '!(' + word2.toJS(0) + ')';
+        word2.toJS(0, this.args.ctx) :
+        '!(' + word2.toJS(0, this.args.ctx) + ')';
     } else {
       return (negated ? '!' : '' ) +
-          "test('" + opString + "', " + word2.toJS(0) +")";
+          "test('" + opString + "', " + word2.toJS(0, this.args.ctx) +")";
     }
   }
 }
@@ -51,9 +64,9 @@ function testCmdHelper(negate, word1, operator, word2) {
 function cmd_helper(opts, args) {
   var params = [];
   if (opts && opts.sourceString)
-    params.push(opts.toJS(0));
+    params.push(opts.toJS(0, this.args.ctx));
   if (args && args.sourceString) {
-    var js_args = args.toJS(0);
+    var js_args = args.toJS(0, this.args.ctx);
     if (typeof js_args === 'string') {
       params.push(js_args);
     } else {
@@ -160,73 +173,107 @@ var semicolonCmdNames = [
 var source2sourceSemantics = {
   Cmd: function(e) {
     return (
-      this.sourceString && e.toJS(this.args.indent) +
+      this.sourceString && e.toJS(this.args.indent, this.args.ctx) +
       (semicolonCmdNames.indexOf(e.ctorName) > -1 ? ';' : '')
     );
   },
   IfCommand: function(ic, eit, elc, ef) {
-    return ic.toJS(this.args.indent) +
-      eit.toJS(this.args.indent) +
-      elc.toJS(this.args.indent) +
-      ef.toJS(this.args.indent);
+    return ic.toJS(this.args.indent, this.args.ctx) +
+      eit.toJS(this.args.indent, this.args.ctx) +
+      elc.toJS(this.args.indent, this.args.ctx) +
+      ef.toJS(this.args.indent, this.args.ctx);
   },
   IfCase: function(_if, _s, cond, _sc, _then, _s2, cmds) {
-    return 'if (' + cond.toJS(this.args.indent) + ') {' + nl(this.args.indent+1) +
-        cmds.toJS(this.args.indent+1);
+    return 'if (' + cond.toJS(this.args.indent, this.args.ctx) + ') {' + nl(this.args.indent+1) +
+        cmds.toJS(this.args.indent+1, this.args.ctx);
   },
   ElseIfThen: function(_sc1, _ei, _s, cond, _sc2, _then, _s2, cmd) {
-    return nl(this.args.indent) + '} else if (' + cond.toJS(this.args.indent) +
-        ') {' + nl(this.args.indent+1) + cmd.toJS(this.args.indent+1);
+    return nl(this.args.indent) + '} else if (' + cond.toJS(this.args.indent, this.args.ctx) +
+        ') {' + nl(this.args.indent+1) + cmd.toJS(this.args.indent+1, this.args.ctx);
   },
   ElseCase: function(_sc, _else, _space, cmd) {
     return nl(this.args.indent) + '} else {' + nl(this.args.indent+1) +
-        cmd.toJS(this.args.indent+1);
+        cmd.toJS(this.args.indent+1, this.args.ctx);
   },
   EndIf: function(_sc, _fi) {
     return nl(this.args.indent) + '}';
   },
-  ForCommand: function(f) { return f.toJS(this.args.indent); },
+  ForCommand: function(f) { return f.toJS(this.args.indent, this.args.ctx); },
   ForCommand_c_style: function(_for, _op, ctrlstruct, _cp, _sc3, _do, _s, cmd, done) {
-    return 'for (' + ctrlstruct.toJS(0) + ') {' +
-        nl(this.args.indent+1) + cmd.toJS(this.args.indent+1) +
+    return 'for (' + ctrlstruct.toJS(0, this.args.ctx) + ') {' +
+        nl(this.args.indent+1) + cmd.toJS(this.args.indent+1, this.args.ctx) +
         nl(this.args.indent) + '}';
   },
   ControlStruct: function(assign, _sc1, id, binop, val, _sc2, update) {
-    return assign.toJS(0) + ';' + id.sourceString + binop.toJS(0) + val.toJS(0) +
+    return assign.toJS(0, this.args.ctx) + ';' + id.sourceString + binop.toJS(0, this.args.ctx) + val.toJS(0, this.args.ctx) +
       ';' + update.sourceString;
   },
   ForCommand_for_each: function(_for, id, _in, call, _sc, _do, _s, cmd2, done) {
-    var mycall = call.toJS(this.args.indent).replace(/\.replace\(.*\)/, '');
+    var mycall = call.toJS(this.args.indent, this.args.ctx).replace(/\.replace\(.*\)/, '');
     return mycall + '.forEach(function (' + id.sourceString + ') {' +
-        nl(this.args.indent+1) + cmd2.toJS(this.args.indent+1) +
+        nl(this.args.indent+1) + cmd2.toJS(this.args.indent+1, this.args.ctx) +
         nl(this.args.indent) + '});';
   },
   WhileCommand: function(_w, _s, cond, _sc, _do, _s2, cmd, done) {
-    return 'while (' + cond.toJS(this.args.indent) + ') {' +
-        nl(this.args.indent+1) + cmd.toJS(this.args.indent+1) +
-        done.toJS(this.args.indent);
+    return 'while (' + cond.toJS(this.args.indent, this.args.ctx) + ') {' +
+        nl(this.args.indent+1) + cmd.toJS(this.args.indent+1, this.args.ctx) +
+        done.toJS(this.args.indent, this.args.ctx);
   },
   Done: function(_sc, _) {
     return nl(this.args.indent) + '}';
   },
   FunctionDecl: function(_fun, _sp1, id, _paren, _sp2, block) {
-    var idStr = id.toJS(0);
+    var idStr = id.toJS(0, this.args.ctx);
     allFunctions[idStr] = true;
 
     inFunctionBody = true;
-    var blockString = block.toJS(this.args.indent);
+    var blockString = block.toJS(this.args.indent, this.args.ctx);
     inFunctionBody = false;
 
     return 'function ' + idStr + '(..._$args) ' + blockString;
   },
+  CaseCommand: function(_case, expr, _in, _ws, cases, _ws2, _esac){
+    var varName = "tmp" + Date.now();
+    var indent = this.args.indent;
+
+    // If we can scan the children to see if there are glob patterns
+    // ahead of time, we can set hasGlob to false and generate cleaner code.
+    var hasGlob = true;
+
+    if (hasGlob){
+      return nl(indent) + "var " + varName + " = " +
+      expr.toJS(0,this.args.ctx) + ";" + nl(indent) +
+      "switch (" + varName + ") {" + nl(indent + 1) +
+      cases.toJS(indent + 1, Object.assign(this.args.ctx,
+        {caseVar:varName})).join(nl(indent + 1)) +
+      nl(indent) + "}";
+    } else {
+      return nl(indent) +
+      "switch (" + expr.toJS(0,this.args.ctx) + ") {" + nl(indent + 1) +
+      cases.toJS(indent + 1, this.args.ctx).join(nl(indent + 1)) +
+      nl(indent) + "}";
+    }
+  },
+  CaseCase: function(opts, _par, _ws, cmds, _ws2, _semisemi, comment){
+    var varName = this.args.ctx.caseVar;
+    var comment = comment.toJS(this.args.indent, this.args.ctx);
+    return opts.toJS(0, this.args.ctx)
+        .map(s => s.substr(1, s.length - 2))
+        .map(s => isGlobString(s) ? ("case " + s + ":")
+          : ("case (" + globStringToRegex(s) + ".test(" + varName + ") ? " + varName + " : NaN) :"))
+        .join(nl(this.args.indent)) +
+      nl(this.args.indent + 1) +
+      cmds.toJS(this.args.indent, this.args.ctx).join(nl(this.args.indent + 1)) +
+      nl(this.args.indent + 1) + "break;" + (comment.length > 0 ? " " + comment : "");
+  },
   TestCmd_cmd: function(_, insides) {
-    return insides.toJS(0);
+    return insides.toJS(0, this.args.ctx);
   },
   TestCmd_singleBracket: function(_ob, _spaces, insides, _cb) {
-    return insides.toJS(0);
+    return insides.toJS(0, this.args.ctx);
   },
   TestCmd_doubleBracket: function(_ob, _spaces, insides, _cb) {
-    return insides.toJS(0);
+    return insides.toJS(0, this.args.ctx);
   },
   TestInsides_unary: function(negate, binop, bw) {
     return testCmdHelper(negate, null, binop, bw);
@@ -238,19 +285,19 @@ var source2sourceSemantics = {
     return testCmdHelper(negate, null, '-n', bw);
   },
   Conditional_test: function(sc) {
-    var ret = sc.toJS(0);
+    var ret = sc.toJS(0, this.args.ctx);
     if (!globalInclude.value && ret.indexOf('test') > -1)
       ret = ret.replace('test(', 'shell.test(');
     return ret;
   },
   Conditional_cmd: function(sc) {
-    return sc.toJS(0) + '.code === 0';
+    return sc.toJS(0, this.args.ctx) + '.code === 0';
   },
   CodeBlock: function(_b1, s1, commandSequence, _s2, _b2) {
     var spaceIc = s1.sourceString;
     return ind(this.args.indent) + '{' +
         (spaceIc && (spaceIc + ind(this.args.indent+1))) +
-        commandSequence.toJS(this.args.indent+1).replace(/ *$/, '') + '}';
+        commandSequence.toJS(this.args.indent+1, this.args.ctx).replace(/ *$/, '') + '}';
   },
   BinaryOp: function(op) {
     var opTable = {
@@ -278,9 +325,9 @@ var source2sourceSemantics = {
 
     return (this.sourceString.match(/^(\s)*$/) ?
           '' :
-          shebang.toJS(this.args.indent) +
+          shebang.toJS(this.args.indent, this.args.ctx) +
         space.sourceString +
-        cmds.toJS(this.args.indent));
+        cmds.toJS(this.args.indent, this.args.ctx));
   },
   Shebang: function(_a, _b, _c) {
     var lines = ['#!/usr/bin/env node'];
@@ -294,27 +341,27 @@ var source2sourceSemantics = {
     return lines.join('\n');
   },
   CmdSequence: function(list) {
-    return list.toJS(this.args.indent).join(nl(this.args.indent));
+    return list.toJS(this.args.indent, this.args.ctx).join(nl(this.args.indent));
   },
   PipeCmd: function(c1, _, spaces, c2) {
     var newlines = spaces.sourceString.replace(/[^\n]/g, '');
-    return c1.toJS(this.args.indent) +
+    return c1.toJS(this.args.indent, this.args.ctx) +
         (newlines ? newlines + ind(this.args.indent+1) : '') +
         '.' +
-        c2.toJS(0).replace(/^shell\./, '');
+        c2.toJS(0, this.args.ctx).replace(/^shell\./, '');
   },
   SimpleCmd: function(scb, redirects, ampersand) {
-    var ret = scb.toJS(this.args.indent) +
-        redirects.toJS(this.args.indent).join('');
+    var ret = scb.toJS(this.args.indent, this.args.ctx) +
+        redirects.toJS(this.args.indent, this.args.ctx).join('');
     if (ampersand.sourceString)
       ret = ret.replace(')', ', {async: true})');
     if (!globalInclude.value) ret = 'shell.' + ret;
     return ret;
   },
-  SimpleCmdBase: function(scb) { return scb.toJS(this.args.indent); },
+  SimpleCmdBase: function(scb) { return scb.toJS(this.args.indent, this.args.ctx); },
   SimpleCmdBase_std: function(firstword, args) {
     var cmd = firstword.sourceString;
-    var argList = args.toJS(0);
+    var argList = args.toJS(0, this.args.ctx);
     var cmdLookup = {
       cp: { opts: 'fnrRLP', arity: [1], },
       rm: { opts: 'frR', arity: [1], },
@@ -374,28 +421,28 @@ var source2sourceSemantics = {
   },
   Redirect: function(arrow, bw) {
     return (arrow.sourceString.match('>>') ? '.toEnd(' : '.to(') +
-        bw.toJS(0) + ')';
+        bw.toJS(0, this.args.ctx) + ')';
   },
   CmdWithComment: function(cmd, comment) {
-    return cmd.toJS(this.args.indent) + '; ' + comment.toJS(this.args.indent);
+    return cmd.toJS(this.args.indent, this.args.ctx) + '; ' + comment.toJS(this.args.indent, this.args.ctx);
   },
   // TODO(nate): make this preserve leading whitespace
   comment: function(leadingWs, _, msg) { return leadingWs.sourceString + '//' + msg.sourceString; },
   Bashword: function(val) {
-    return val.toJS(0);
+    return val.toJS(0, this.args.ctx);
   },
   ArrayLiteral: function(_op, _sp1, bws, _sp2, _cp) {
-    return '[' + bws.toJS(0).join(', ') + ']';
+    return '[' + bws.toJS(0, this.args.ctx).join(', ') + ']';
   },
-  reference: function(r) { return r.toJS(0); },
+  reference: function(r) { return r.toJS(0, this.args.ctx); },
   reference_simple: function(_, id) {
-    return '$$' + envGuess(id.toJS(0));
+    return '$$' + envGuess(id.toJS(0, this.args.ctx));
   },
   reference_wrapped: function(_, id, _2) {
-    return '$$' + envGuess(id.toJS(0));
+    return '$$' + envGuess(id.toJS(0, this.args.ctx));
   },
   reference_substr: function(_ob, id, _col, dig, _col2, dig2, _cb) {
-    return '$$' + id.toJS(0) + '.substr(' + dig.sourceString +
+    return '$$' + id.toJS(0, this.args.ctx) + '.substr(' + dig.sourceString +
         (dig2.sourceString ? ', ' + dig2.sourceString : '') +
         ')';
   },
@@ -403,23 +450,23 @@ var source2sourceSemantics = {
     var patStr = _sl1.sourceString === "//" ?
         new RegExp(pat.sourceString, 'g').toString() :
         JSON.stringify(pat.sourceString);
-    return '$$' + id.toJS(0) + '.replace(' +
+    return '$$' + id.toJS(0, this.args.ctx) + '.replace(' +
         patStr + ', ' +
         JSON.stringify((sub.sourceString) || '') + ')';
   },
   reference_length: function(_ob, id, _cb) {
-    return '$$' + id.toJS(0) + '.length';
+    return '$$' + id.toJS(0, this.args.ctx) + '.length';
   },
   notDoubleQuote_escape: function(_, _2) { return this.sourceString; },
   bareWord: function(chars) {
-    return ("'" + chars.toJS(0).join('') + "'").replace(/^'' \+ /g, '').replace(/ \+ ''/g, '');
+    return ("'" + chars.toJS(0, this.args.ctx).join('') + "'").replace(/^'' \+ /g, '').replace(/ \+ ''/g, '');
   },
-  barewordChar: function(ch) { return ch.toJS(0); },
+  barewordChar: function(ch) { return ch.toJS(0, this.args.ctx); },
   barewordChar_str: function(mystring) {
-    return "' + " + mystring.toJS(0) + " + '";
+    return "' + " + mystring.toJS(0, this.args.ctx) + " + '";
   },
   barewordChar_normal: function(atom) {
-    atom = atom.toJS(0);
+    atom = atom.toJS(0, this.args.ctx);
     if (atom.substr(0, 2) === '$$') { // a hack
       // This is a variable
       return "' + " + atom.slice(2) + " + '";
@@ -429,15 +476,15 @@ var source2sourceSemantics = {
     }
   },
   barewordChar_escape: function(_, c) {
-    return c.toJS(0);
+    return c.toJS(0, this.args.ctx);
   },
-  stringLiteral: function(string) { return string.toJS(this.args.indent); },
+  stringLiteral: function(string) { return string.toJS(this.args.indent, this.args.ctx); },
   singleString: function(_sq, val, _eq) {
     return "'" + val.sourceString.replace(/\n/g, '\\n') + "'";
   },
   doubleString: function(_sq, val, _eq) {
     var ret = '';
-    val.toJS(0).forEach(function (atom) {
+    val.toJS(0, this.args.ctx).forEach(function (atom) {
       if (atom.substr(0, 2) === '$$') { // a hack
         // This is a variable
         ret += "' + " + atom.slice(2) + " + '";
@@ -472,20 +519,20 @@ var source2sourceSemantics = {
     return ret;
   },
   Call: function(_s, cmd, _e) {
-    return cmd.toJS(0).replace(/;$/, '') + ".replace(/\\n+$/, '')";
+    return cmd.toJS(0, this.args.ctx).replace(/;$/, '') + ".replace(/\\n+$/, '')";
   },
-  arrayReference: function(_s, arrId, _e) { return arrId.toJS(0); },
-  arrayLength: function(_s, arrId, _e) { return arrId.toJS(0) + '.length'; },
+  arrayReference: function(_s, arrId, _e) { return arrId.toJS(0, this.args.ctx); },
+  arrayLength: function(_s, arrId, _e) { return arrId.toJS(0, this.args.ctx) + '.length'; },
   Export: function(e) {
-    return e.toJS(this.args.indent);
+    return e.toJS(this.args.indent, this.args.ctx);
   },
   Export_bare: function(_, id) {
-    id_str = id.toJS(0);
+    id_str = id.toJS(0, this.args.ctx);
     return (id_str.match(/env\./) ? id_str : env(id_str)) +
         ' = ' + id_str;
   },
   Export_assign: function(_, assign) {
-    assign_str = assign.toJS(0).replace(/^(var|const) /, '');
+    assign_str = assign.toJS(0, this.args.ctx).replace(/^(var|const) /, '');
     var id = assign_str.match(/^([^ ]+) =/)[1];
     return (id.match(/env\./) ? '' : env(id) + ' = ') +
         assign_str;
@@ -494,7 +541,7 @@ var source2sourceSemantics = {
     // Check if this variable is assigned already. If not, stick it in the
     // environment
     var ret;
-    var varName = name.toJS(0).trim();
+    var varName = name.toJS(0, this.args.ctx).trim();
     if (varName.match(/^(shell.)?env.|^process.argv.|^_\$args./) || globalEnvironment[varName]) {
       ret = '';
     } else {
@@ -502,7 +549,7 @@ var source2sourceSemantics = {
       globalEnvironment[varName] = true; // mark it as declared
     }
 
-    var myexpr = expr.toJS(this.args.indent).toString();
+    var myexpr = expr.toJS(this.args.indent, this.args.ctx).toString();
     var ic = expr.sourceString;
     ret += varName + " = " + (myexpr || "''");
     return ret;
@@ -511,7 +558,7 @@ var source2sourceSemantics = {
     return this.sourceString;
   },
   NonemptyListOf: function(x, sep, xs) {
-    return [x.toJS(this.args.indent)].concat(xs.toJS(this.args.indent));
+    return [x.toJS(this.args.indent, this.args.ctx)].concat(xs.toJS(this.args.indent, this.args.ctx));
   },
   EmptyListOf: function() {
     return [];

--- a/test/case/test.js
+++ b/test/case/test.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+require('shelljs/global');
+env.FRUIT = 'kiwi';
+
+
+var $tmp0 = env.FRUIT;
+switch ($tmp0) {
+  case (/^a.*$/g.test($tmp0) ? $tmp0 : NaN) :
+    echo('FFFF a');
+    break; // this is a comment
+  case (/^b.*$/g.test($tmp0) ? $tmp0 : NaN) :
+    echo('FFFF b');
+    echo('test');
+    break;
+  case (/^c.*$/g.test($tmp0) ? $tmp0 : NaN) :
+  case 'kiwi':
+    echo('FFFF c kiwi');
+    break;
+  case (/^.*$/g.test($tmp0) ? $tmp0 : NaN) :
+    echo('FFFF other');
+    break;
+}

--- a/test/case/test.sh
+++ b/test/case/test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+FRUIT="kiwi"
+
+case "$FRUIT" in
+  a*) echo "FFFF a" ;; # this is a comment
+  b*) echo "FFFF b" ;
+  echo "test";;
+  c*|kiwi) echo "FFFF c kiwi" ;;
+  *) echo "FFFF other" ;;
+esac


### PR DESCRIPTION
Weird, I could have sworn I submitted a PR of this a couple days ago but now I can't find it.

This addresses #16 by adding support for switch statements.  I added some capability to print it nicer if there are no glob patterns in the cases, but couldn't figure out how to traverse the AST.

The reason that there are a lot of changes is I tweaked the printer to pass forward a context object.  If you don't like this we can talk.