### PR TITLE
chore: limit test coverage to 1P code

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "release:minor": "shelljs-release minor",
     "release:patch": "shelljs-release patch"
   },
+  "nyc": {
+    "include": ["scripts/", "src/"]
+  },
   "author": "Nate Fischer <ntfschr@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Don't include 3P code (e.g., ohm, codemirror, etc.) when running code
coverage.