### PR TITLE
chore: update GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,22 +13,24 @@ jobs:
           - 18
           - 20
           - 22
+          - 24
+          - 26
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
     steps:
       - name: Checkout repository and submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
       - run: npm run test
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
No change to logic. This updates GitHub Actions to their latest
versions. This also ensures we are testing up through Node v26.

The most important part of this is that it updates codecov to v7, which
contains a major bug fix that was blocking all codecov uploads (and
failing all CI test runs).
